### PR TITLE
Static array declaration

### DIFF
--- a/src/assets/prism-armv7.ts
+++ b/src/assets/prism-armv7.ts
@@ -1,78 +1,79 @@
 import { languages } from 'prismjs'
+import { tokens } from '@/constants/tokens';
 
 export const branchRegex = /\b(b|bl|bx)(eq|ne|cs|cc|mi|pl|vs|vc|hi|ls|ge|lt|gt|le|al)?\b/i
 
 languages.armv7 =  {
-	'string': {
+	[tokens.string]: {
 		pattern: /"(?:\\(?:\r\n|[\s\S])|[^"\\\r\n])*"/
 	},
-	'line-comment': {
+	[tokens.line_comment]: {
 		pattern: /\/\/(?:[^\r\n\\]|\\(?:\r\n?|\n|(?![\r\n])))*|\/\*[\s\S]*?(?:\*\/|$)/,
 		greedy: true
 	},
-	'bi-operand': {
+	[tokens.bi_operand]: {
 		pattern: /\b(cmn|cmp|mov|mvn|teq|tst)(s)?(eq|ne|cs|cc|mi|pl|vs|vc|hi|ls|ge|lt|gt|le|al)?\b/i,
 		alias: 'operation'
 	},
-	'tri-operand': {
+	[tokens.tri_operand]: {
 		pattern: /\b(adc|add|and|bic|eor|orr|rsb|rsc|sbc|sub)(s)?(eq|ne|cs|cc|mi|pl|vs|vc|hi|ls|ge|lt|gt|le|al)?\b/i,
 		alias: 'operation'
 	},
-	'branch': {
+	[tokens.branch]: {
 		pattern: branchRegex,
 		alias: 'operation'
 	},
-	'shift': {
+	[tokens.shift]: {
 		pattern: /\b(lsl|lsr|asr|ror|rrx)(eq|ne|cs|cc|mi|pl|vs|vc|hi|ls|ge|lt|gt|le|al)?\b/i,
 		alias: 'operation'
 	},
-	'single-transfer': { 
+	[tokens.transfer.single]: { 
 		pattern: /\b(str|ldr)(b)?(eq|ne|cs|cc|mi|pl|vs|vc|hi|ls|ge|lt|gt|le|al)?\b/i,
 		alias: 'operation'
 	},
-	'block-transfer': {
+	[tokens.transfer.block]: {
 		pattern: /\b(stm|ldm)(eq|ne|cs|cc|mi|pl|vs|vc|hi|ls|ge|lt|gt|le|al)?(fd|ed|fa|ea|ia|ib|da|db)?\b/i,
 		alias: 'operation'
 	},
-	'stack-transfer': {
+	[tokens.transfer.stack]: {
 		pattern: /\b(push|pop)(eq|ne|cs|cc|mi|pl|vs|vc|hi|ls|ge|lt|gt|le|al)?\b/i,
 		alias: 'operation'
 	},
-	'register': {
+	[tokens.register]: {
 		pattern: /\b(r([0-9]|(10|11|12))|(sp|lr|pc))\b/i,
 	},
-	'immediate': [
+	[tokens.immediate]: [
 		{ pattern: /#\b0x(\d|[a-f])+\b/i, alias: 'hex' },
 		{ pattern: /#\b0b(0|1)+\b/i, alias: 'bin' },
 		{ pattern: /#\b0[0-7]+\b/i, alias: 'oct' },
 		{ pattern: /#\b(0d)?(\d)+\b/i, alias: 'dec' }
 	],
-	'number': [
+	[tokens.number]: [
 		{ pattern: /\b0x(\d|[a-f])+\b/i, alias: 'hex' },
 		{ pattern: /\b0b(0|1)+\b/i, alias: 'bin' },
 		{ pattern: /\b0[0-7]+\b/i, alias: 'oct' },
 		{ pattern: /\b(0d)?(\d)+\b/i, alias: 'dec' }
 	],
-	'indexer': [
+	[tokens.indexer]: [
 		{ pattern: /\[/, alias: 'start' },
 		{ pattern: /\]/, alias: 'end' },
 	],
-	'reg-list': [
+	[tokens.reg_list]: [
 		{ pattern: /\{/, alias: 'start' },
 		{ pattern: /\}/, alias: 'end' },
 	],
 	// 'number': /(?:\b|(?=\$))(?:0[hx](?:\.[\da-f]+|[\da-f]+(?:\.[\da-f]+)?)(?:p[+-]?\d+)?|\d[\da-f]+[hx]|\$\d[\da-f]*|0[oq][0-7]+|[0-7]+[oq]|0[by][01]+|[01]+[by]|0[dt]\d+|(?:\d+(?:\.\d+)?|\.\d+)(?:\.?e[+-]?\d+)?[dt]?)\b/i,
-	'comma': /,/,
-	'directive': /\.\b(text|data|global|extern|byte|hword|word|asciz|skip|balign)\b/m,
-	'data-label': /=\b[A-Za-z_][A-Za-z_\d]+\b/m,
-	'sign': [
+	[tokens.comma]: /,/,
+	[tokens.directive]: /\.\b(text|data|global|extern|byte|hword|word|asciz|skip|balign)\b/m,
+	[tokens.data_label]: /=\b[A-Za-z_][A-Za-z_\d]+\b/m,
+	[tokens.sign]: [
 		{ pattern: /-/m, alias: "minus" },
 		{ pattern: /\+/m, alias: "plus" }
 	],
-	'updating': /!/m,
-	'label': /\b[A-Za-z_][A-Za-z_\d]+\b:/m,
-	'op-label': /\b[A-Za-z_][A-Za-z_\d]+\b/m,
-	'end': /\n/m,
-	'whitespace': /\s+/,
-	'unknown': /.+/
+	[tokens.updating]: /!/m,
+	[tokens.label]: /\b[A-Za-z_][A-Za-z_\d]+\b:/m,
+	[tokens.op_label]: /\b[A-Za-z_][A-Za-z_\d]+\b/m,
+	[tokens.end]: /\n/m,
+	[tokens.whitespace]: /\s+/,
+	[tokens.unknown]: /.+/
 };

--- a/src/assets/scanf/scanf.js
+++ b/src/assets/scanf/scanf.js
@@ -245,7 +245,7 @@ var dealType = function(format) {
     case '%u':
       ret = getInteger(pre, next);
       break;
-    case '%c': // TODO getChar
+    case '%c':
       ret = getChar(pre, next);
       break;
     case '%s':

--- a/src/constants/allocation.ts
+++ b/src/constants/allocation.ts
@@ -9,3 +9,15 @@ export const dataTypeMap: Record<string, DataType> = {
   '.asciz': DataType.BYTE,
   '.skip': DataType.BYTE
 }
+
+export const dataTypeBitSizeMap = {
+  [DataType.BYTE]: 8,
+  [DataType.HWORD]: 16,
+  [DataType.WORD]: 32
+} as const;
+
+export const dataTypeBufferConstructorMap = {
+  [DataType.BYTE]: Uint8Array,
+  [DataType.HWORD]: Uint16Array,
+  [DataType.WORD]: Uint32Array
+} as const;

--- a/src/constants/allocation.ts
+++ b/src/constants/allocation.ts
@@ -10,6 +10,12 @@ export const dataTypeMap: Record<string, DataType> = {
   '.skip': DataType.BYTE
 }
 
+export const dataTypeByteSizeMap = {
+  [DataType.BYTE]: 1,
+  [DataType.HWORD]: 2,
+  [DataType.WORD]: 4
+}
+
 export const dataTypeBitSizeMap = {
   [DataType.BYTE]: 8,
   [DataType.HWORD]: 16,

--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -1,0 +1,33 @@
+export const tokens = {
+  // operations
+  bi_operand: "bi-operand",
+  tri_operand: "tri-operand",
+  branch: "branch",
+  shift: "shift",
+  transfer: {
+    single: "single-transfer",
+    block: "block-transfer",
+    stack: "stack-transfer",
+  } as const,
+  
+  // components
+  string: "string",
+  register: "register",
+  immediate: "immediate",
+  number: "number",
+  indexer: "indexer",
+  reg_list: "reg-list",
+  comma: "comma",
+  data_label: "data-label",
+  sign: "sign",
+  updating: "updating",
+  label: "label",
+  op_label: "op-label",
+
+  // auxiliary
+  directive: "directive",
+  line_comment: "line-comment",
+  end: "end",
+  whitespace: "whitespace",
+  unknown: "unknown"
+} as const;

--- a/src/constants/transfer.ts
+++ b/src/constants/transfer.ts
@@ -1,6 +1,6 @@
-export enum SingleTransfer  { LDR, STR }
-export enum BlockTransfer   { LDM, STM }
-export enum StackTransfer   { POP, PUSH }
+export enum SingleTransfer  { LDR = 0, STR = 1 }
+export enum BlockTransfer   { LDM = 2, STM = 3 }
+export enum StackTransfer   { POP = 4, PUSH = 5 }
 export type TTransfer = SingleTransfer | BlockTransfer | StackTransfer;
 
 export const transferMap: Record<string, TTransfer> = {

--- a/src/interpreter/error.ts
+++ b/src/interpreter/error.ts
@@ -82,6 +82,13 @@ export class SyntaxError extends IriscError {
   constructor(message: string, statement: Token[], lineNumber: number, tokenIndex: number) {
     super(message, statement, lineNumber, tokenIndex);
   }
+
+  static badToken(expected: string, received: Token, statement: Token[], lineNumber: number, tokenIndex: number) {
+    return new SyntaxError(
+      `${expected.toUpperCase()} value expected - received ${received.type.toUpperCase()} '${received.content}' instead.`, 
+      statement, lineNumber, tokenIndex
+    );
+  }
 } 
 
 /**

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -1,5 +1,5 @@
 import { rotr } from "@/assets/bitset";
-import { addressModeGroup, BlockTransfer, callAddress, callMap, Flag, Operation, Register, Shift, SingleTransfer, TTransferSize } from "@/constants";
+import { addressModeGroup, BlockTransfer, callAddress, callMap, Flag, OperandType, Operation, opTitle, Register, Shift, SingleTransfer, TTransferSize } from "@/constants";
 import { SimulatorState } from "@/simulator";
 import { BiOperandNode, FlexOperand, ShiftNode, TriOperandNode, BranchNode, BlockTransferNode, SingleTransferNode } from "@/syntax";
 import { TInstructionNode } from "@/syntax/types";
@@ -89,8 +89,8 @@ function applyFlexShift(shift: Shift, value: number, amount: number) : number {
     case Shift.ROR:
       return rotr(value, amount);
     default:
-      // TODO: get executing instruction from the EmulatorState and populate the error location params
-      throw new RuntimeError("While attempting to perform a flex operand optional shift.", [], -1);
+      let instruction = state.memory.text[state.registers[Register.PC]];
+      throw new RuntimeError("While attempting to perform a flex operand optional shift.", instruction.statement, instruction.lineNumber);
   }
 }
 
@@ -186,8 +186,8 @@ function executeTriOperand(instruction: TriOperandNode) : boolean {
   } 
 
   if (result === undefined) {
-    // TODO: get executing instruction from the EmulatorState and populate the error location params
-    throw new RuntimeError("While attempting to perform a an instruction.", [], -1);
+    let instruction = state.memory.text[state.registers[Register.PC]];
+    throw new RuntimeError(`While attempting to perform a '${opTitle[op]}' instruction.`, instruction.statement, instruction.lineNumber);
   }
 
   SimulatorState.setRegister(dest, result);

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -1,5 +1,5 @@
 import { rotr } from "@/assets/bitset";
-import { addressModeGroup, BlockTransfer, callAddress, callMap, Flag, OperandType, Operation, opTitle, Register, Shift, SingleTransfer, TTransferSize } from "@/constants";
+import { addressModeGroup, BlockTransfer, callAddress, callMap, Flag, Operation, opTitle, Register, Shift, SingleTransfer, TTransferSize } from "@/constants";
 import { SimulatorState } from "@/simulator";
 import { BiOperandNode, FlexOperand, ShiftNode, TriOperandNode, BranchNode, BlockTransferNode, SingleTransferNode } from "@/syntax";
 import { TInstructionNode } from "@/syntax/types";

--- a/src/simulator/actions/memory/text.ts
+++ b/src/simulator/actions/memory/text.ts
@@ -31,6 +31,7 @@ export const text = {
     });
 
     state.currentInstruction = undefined;
+    state.cpu.tick = 0;
 
     memory.observeMemory();
     snapshots.takeSnapshot();

--- a/src/syntax/AllocationNode.ts
+++ b/src/syntax/AllocationNode.ts
@@ -1,5 +1,5 @@
 import { bitset } from "@/assets/bitset";
-import { DataType, dataTypeMap } from '@/constants';
+import { DataType, dataTypeBufferConstructorMap, dataTypeMap, dataTypeBitSizeMap } from '@/constants';
 import { Token } from "prismjs";
 import { SyntaxError } from "../interpreter/error";
 import { SyntaxNode } from "./SyntaxNode";
@@ -7,37 +7,35 @@ import { tokens } from "@/constants/tokens";
 
 export class AllocationNode extends SyntaxNode {
   protected _identifier: string;
-  protected _data: Uint8Array;
+  protected _data: ArrayBuffer;
 
   protected _type: DataType;
   private _specificType!: string;
 
   get identifier() : string { return this._identifier; }
-  get data() : Uint8Array { return this._data; }
+  get data() : Uint8Array { return new Uint8Array(this._data); }
   get type() : string { return this._specificType; }
 
   constructor(statement: Token[], lineNumber: number, currentToken: number = 0) {
     super(statement, lineNumber, currentToken);
 
     this._identifier = (this.nextToken().content as string).slice(0, -1);
-    this._type = dataTypeMap[this.nextToken().content as string];
-    this._data = this.parseData(this.peekToken());
+    this._type = dataTypeMap[this.peekToken().content as string];
+    this._specificType = this.nextToken().content as string;
 
-    this.nextToken();
+    this._data = this.parseData();
 
     if (this.hasToken()) throw new SyntaxError(`Unexpected token '${this.peekToken().content}' after valid data declaration end.`, statement, lineNumber, currentToken);
   }
 
-  parseData(token: Token) : Uint8Array {
-    this._specificType = this.previousToken().content as string;
+  parseData() : ArrayBuffer {
+    if (this._specificType === ".asciz") return this.parseString(this.nextToken());
+    if (this._specificType === ".byte") return this.parseIntArray(DataType.BYTE);
+    if (this._specificType === ".hword") return this.parseIntArray(DataType.HWORD);
+    if (this._specificType === ".word") return this.parseIntArray(DataType.WORD);
+    if (this._specificType === ".skip") return this.parseSkip(this.nextToken());
 
-    if (this.previousToken().content === ".asciz") return this.parseString(token);
-    if (this.previousToken().content === ".byte") return this.parseByte(token);
-    if (this.previousToken().content === ".hword") return this.parseHWord(token);
-    if (this.previousToken().content === ".word") return this.parseWord(token);
-    if (this.previousToken().content === ".skip") return this.parseSkip(token);
-
-    throw new SyntaxError(`Unrecognised data type '${this.previousToken().content}'.`, this.statement, this.lineNumber, this._currentToken - 1)
+    throw new SyntaxError(`Unrecognised data type '${this._specificType}'.`, this.statement, this.lineNumber, this._currentToken - 1)
   }
 
   parseString(token: Token) : Uint8Array {
@@ -45,7 +43,7 @@ export class AllocationNode extends SyntaxNode {
       throw SyntaxError.badToken(tokens.string, token, this._statement, this._lineNumber, this._currentToken);
     }
 
-    const string = (token.content as string).slice(1, -1);
+    const string = (token.content as string).slice(1, -1);    // slice off quotes
     const withEscapes = JSON.parse(`"${string}"`);
     const data = new Uint8Array(new ArrayBuffer(withEscapes.length + 1));
 
@@ -54,30 +52,20 @@ export class AllocationNode extends SyntaxNode {
     return data;
   }
 
-  parseByte(token: Token) : Uint8Array {
-    const data = new Uint8Array(new ArrayBuffer(1));
-    const bits = bitset(8, this.parseNum(token));
-    data[0] = parseInt(bits.join(''), 2);
+  parseIntArray(size: DataType) : ArrayBuffer {
+    const ints: number[] = [this.parseSizedInt(this.nextToken(), size)];
 
-    return data;
+    while (this.hasToken()) {
+      this.parseComma(this.nextToken());
+      ints.push(this.parseSizedInt(this.nextToken(), size));
+    }
+
+    return new dataTypeBufferConstructorMap[size](ints);
   }
 
-  parseHWord(token: Token) : Uint8Array {
-    const buffer = new ArrayBuffer(2);
-    const data = new Uint16Array(buffer);
-    const bits = bitset(16, this.parseNum(token));
-    data[0] = parseInt(bits.join(''), 2);
-
-    return new Uint8Array(buffer);
-  }
-
-  parseWord(token: Token) : Uint8Array {
-    const buffer = new ArrayBuffer(4);
-    const data = new Uint32Array(buffer);
-    const bits = bitset(32, this.parseNum(token));
-    data[0] = parseInt(bits.join(''), 2);
-
-    return new Uint8Array(buffer);
+  parseSizedInt(token: Token, size: DataType) : number {
+    const bits = bitset(dataTypeBitSizeMap[size], this.parseNum(token));
+    return parseInt(bits.join(''), 2);
   }
 
   parseSkip(token: Token) : Uint8Array {

--- a/src/syntax/AllocationNode.ts
+++ b/src/syntax/AllocationNode.ts
@@ -3,6 +3,7 @@ import { DataType, dataTypeMap } from '@/constants';
 import { Token } from "prismjs";
 import { SyntaxError } from "../interpreter/error";
 import { SyntaxNode } from "./SyntaxNode";
+import { tokens } from "@/constants/tokens";
 
 export class AllocationNode extends SyntaxNode {
   protected _identifier: string;
@@ -41,7 +42,7 @@ export class AllocationNode extends SyntaxNode {
 
   parseString(token: Token) : Uint8Array {
     if (token.type !== "string") {
-      throw new SyntaxError(`Expected STRING - received ${token.type.toUpperCase()} '${token.content}' instead.`, this.statement, this.lineNumber, this._currentToken);
+      throw SyntaxError.badToken(tokens.string, token, this._statement, this._lineNumber, this._currentToken);
     }
 
     const string = (token.content as string).slice(1, -1);
@@ -55,7 +56,7 @@ export class AllocationNode extends SyntaxNode {
 
   parseByte(token: Token) : Uint8Array {
     const data = new Uint8Array(new ArrayBuffer(1));
-    const bits = bitset(8, this.parseImm(token));
+    const bits = bitset(8, this.parseNum(token));
     data[0] = parseInt(bits.join(''), 2);
 
     return data;
@@ -64,7 +65,7 @@ export class AllocationNode extends SyntaxNode {
   parseHWord(token: Token) : Uint8Array {
     const buffer = new ArrayBuffer(2);
     const data = new Uint16Array(buffer);
-    const bits = bitset(16, this.parseImm(token));
+    const bits = bitset(16, this.parseNum(token));
     data[0] = parseInt(bits.join(''), 2);
 
     return new Uint8Array(buffer);
@@ -73,14 +74,14 @@ export class AllocationNode extends SyntaxNode {
   parseWord(token: Token) : Uint8Array {
     const buffer = new ArrayBuffer(4);
     const data = new Uint32Array(buffer);
-    const bits = bitset(32, this.parseImm(token));
+    const bits = bitset(32, this.parseNum(token));
     data[0] = parseInt(bits.join(''), 2);
 
     return new Uint8Array(buffer);
   }
 
   parseSkip(token: Token) : Uint8Array {
-    const length = this.parseImm(token);
+    const length = this.parseNum(token);
     
     return new Uint8Array(new ArrayBuffer(length));
   }

--- a/src/syntax/DirectiveNode.ts
+++ b/src/syntax/DirectiveNode.ts
@@ -63,7 +63,7 @@ export class DirectiveNode extends SyntaxNode {
   }
 
   private parseBalign() {
-    const size = this.parseImm(this.nextToken());
+    const size = this.parseNum(this.nextToken());
     this._value = size;
   }
 }

--- a/src/syntax/SyntaxNode.ts
+++ b/src/syntax/SyntaxNode.ts
@@ -2,6 +2,7 @@ import { bitset, ffs, fls, rotr } from '@/assets/bitset';
 import { Register, regMap } from '@/constants';
 import { Token } from 'prismjs';
 import { NumericalError, SyntaxError } from '../interpreter/error';
+import { tokens } from '@/constants/tokens';
 
 /** Ancestor class which defines common functions for all child syntax nodes */
 export class SyntaxNode {
@@ -85,7 +86,7 @@ export class SyntaxNode {
    */
   parseComma(token: Token) : boolean {
     if (token.type == "comma") return true;
-    else throw new SyntaxError("COMMA expected between operands - received " + token.type + " '" + token.content + "', instead.", this._statement, this._lineNumber, this._currentToken - 1);
+    else throw SyntaxError.badToken(tokens.comma, token, this._statement, this._lineNumber, this._currentToken);
   }
 
   /**
@@ -95,7 +96,7 @@ export class SyntaxNode {
    */
   parseReg(token: Token) : Register {
     if (token.type == "register") return regMap[token.content as string];
-    else throw new SyntaxError("REGISTER expected - received " + token.type.toUpperCase() + " '" + token.content + "' instead.", this._statement, this._lineNumber, this._currentToken - 1);
+    else throw SyntaxError.badToken(tokens.register, token, this._statement, this._lineNumber, this._currentToken);
   }
 
   /**
@@ -105,6 +106,14 @@ export class SyntaxNode {
    * @returns 
    */
   parseImm(token: Token, bits?: number) : number {
+    if (token.type != tokens.immediate) {
+      throw SyntaxError.badToken(tokens.immediate, token, this._statement, this._lineNumber, this._currentToken);
+    }
+    
+    return this.parseNum(token, bits);
+  }
+
+  parseNum(token: Token, bits?: number) : number {
     let base: number = 0;
     let start: number;
     const reveresedToken = [...(token.content as string)].reverse();
@@ -125,7 +134,7 @@ export class SyntaxNode {
       base = 16;
       start = reveresedToken.findIndex(e => !"0123456789abcdef".includes(e));
     }
-    else throw new SyntaxError("IMMEDIATE value expected - received " + token.type.toUpperCase() + " '" + token.content + "' instead.", this._statement, this._lineNumber, this._currentToken);
+    else throw SyntaxError.badToken(tokens.immediate, token, this._statement, this._lineNumber, this._currentToken);
 
     // correct start index for tokens which don't have '#' or '0n' identifiers
     start = start === -1 ? reveresedToken.length : start;
@@ -135,7 +144,6 @@ export class SyntaxNode {
 
     if (!bits || imm < Math.pow(2, bits)) return imm;
     else throw new NumericalError("IMMEDIATE value '" + token.content + "' (decimal " + imm + ") is greater than the " + bits + "-bit maximum.", this._statement, this._lineNumber, this._currentToken)
-    
   }
 
   /**

--- a/src/syntax/transfer/SingleTransferNode.ts
+++ b/src/syntax/transfer/SingleTransferNode.ts
@@ -216,7 +216,7 @@ export class SingleTransferNode extends TransferNode {
     });
     
     const sizeBit = this._transferSize === "byte" ? 1 : 0;         
-    instruction = (instruction << 1) | upDownBit;
+    instruction = (instruction << 1) | sizeBit;
     explanation.push({
       title: "Byte/Word Bit", 
       subtitle: sizeBit ? "Byte" : "Word", 
@@ -291,10 +291,6 @@ export class SingleTransferNode extends TransferNode {
         range: 4
       });
 
-      // TODO: not very robust, needs to be able to generate more complex flexoperand values to
-      // reference labels which out of the 255 range.
-      // const labelOffset = Interpreter.generateLabelOffset(this);
-
       // empty barrel shifter - could try to reference more distance addresses 
       instruction = (instruction << 4); 
       explanation.push({
@@ -313,10 +309,6 @@ export class SingleTransferNode extends TransferNode {
         range: 8
       });
     }
-
-
-    // TODO: finish implementation
-    // instruction <<= 20;
 
     return {
       bitcode: bitset(32, instruction).reverse(), 


### PR DESCRIPTION
## Features
Adds support for static array declaration with `.byte`, `.hword` and `.word` datatypes, like so:

```
.data
.balign 4
 // creates a static byte array of length 6 with the comma separate values provided
bytes: .byte 1, 2, -3, -4, 5, 6    

.balign 4
 // creates a static hword array of length 3 with the comma separate values provided
hwords: .hword 2, 4, -8

.balign 4
 // creates a static word array of length 5 with the comma separate values provided
words: .word -1, -2, 3, 4, 5
```

The above results in something like the following in the memory explorer:

![image](https://github.com/user-attachments/assets/9529f6f2-9cc4-439d-88bc-c1a3058fc9ea)

The `type:` field in the bottom left tooltip now additionally displays the length of the array if the declared data is an array type - here `type: .byte [6]`

## Fixes
Also fixed an annoying bug where changing the editor file after running meant that you couldn't rerun the program without refreshing.
